### PR TITLE
Add folderselect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ React dropbox chooser
 ============
 Simple react wrapper for [Dropbox Chooser API](https://www.dropbox.com/developers/chooser)
 
-Installation 
+Installation
 ============
 ```
 npm install react-dropbox-chooser
@@ -11,17 +11,18 @@ npm install react-dropbox-chooser
 Usage
 =====
 ```
-<DropboxChooser 
+<DropboxChooser
     appKey={'your-uniq-app-key'}
     success={files => this.onSuccess(files)}
     cancel={() => this.onCancel()}
     multiselect={true}
+    folderselect={true}
     extensions={['.mp4']} >
-    <div className="dropbox-button">Click me!</div>        
+    <div className="dropbox-button">Click me!</div>
 </DropboxChooser>
 ```
 
-Demo 
+Demo
 ====
 ```
 npm install

--- a/src/react-dropbox-chooser.js
+++ b/src/react-dropbox-chooser.js
@@ -16,16 +16,18 @@ export default class DropboxChooser extends Component {
     appKey: PropTypes.string.isRequired,
     success: PropTypes.func.isRequired,
     cancel: PropTypes.func,
-    linkType: PropTypes.oneOf([ 'preview', 'direct' ]),
+    linkType: PropTypes.oneOf(['preview', 'direct']),
     multiselect: PropTypes.bool,
+    folderselect: PropTypes.bool,
     extensions: PropTypes.arrayOf(PropTypes.string),
     disabled: PropTypes.bool
   };
 
   static defaultProps = {
-    cancel: () => {},
+    cancel: () => { },
     linkType: 'preview',
     multiselect: false,
+    folderselect: false,
     disabled: false
   };
 
@@ -39,7 +41,7 @@ export default class DropboxChooser extends Component {
     if (!this.isDropboxReady() && !scriptLoadingStarted) {
       scriptLoadingStarted = true;
       loadScript(DROPBOX_SDK_URL, {
-        attrs : {
+        attrs: {
           id: SCRIPT_ID,
           'data-app-key': this.props.appKey
         }
@@ -61,6 +63,7 @@ export default class DropboxChooser extends Component {
       cancel,
       linkType,
       multiselect,
+      folderselect,
       extensions
     } = this.props;
 
@@ -69,6 +72,7 @@ export default class DropboxChooser extends Component {
       cancel,
       linkType,
       multiselect,
+      folderselect,
       extensions
     });
   }
@@ -78,8 +82,8 @@ export default class DropboxChooser extends Component {
       <div onClick={this.onChoose}>
         {
           this.props.children ?
-              this.props.children :
-              <button>Open dropbox chooser</button>
+            this.props.children :
+            <button>Open dropbox chooser</button>
         }
       </div>
     );


### PR DESCRIPTION
A new option:

```
// Optional. A value of false (default) limits selection to files,
// while true allows the user to select both folders and files.
// You cannot specify `linkType: "direct"` when using `folderselect: true`.
folderselect: false, // or true
```